### PR TITLE
Fix: plotly visualization on homepage

### DIFF
--- a/templates/master.html
+++ b/templates/master.html
@@ -28,6 +28,18 @@
         {% endwith %}
         {% block message %}{% endblock %}
         {% block content %}{% endblock %}
+
+        {% for id in ids %}
+        <div id="{{id}}"></div>
+        {% endfor %}
     </div>
+
+    <script type="text/javascript">
+        const graphs = {{graphJSON | safe}};
+        const ids = {{ids | safe}};
+        for(let i in graphs) {
+            Plotly.plot(ids[i], graphs[i].data, graphs[i].layout);
+        }
+    </script>
 </body>
 </html>


### PR DESCRIPTION
The code which was necessary to render the Plotly graphs on the master.html page was not included in the file. The added code in this fix dynamically generates Plotly graphs within the HTML page based on the JSON data provided. 